### PR TITLE
Multiple robots: move constants for each robot into different files

### DIFF
--- a/src/main/java/frc/robot/RobotConstants2019.java
+++ b/src/main/java/frc/robot/RobotConstants2019.java
@@ -1,0 +1,8 @@
+package frc.robot;
+
+public class RobotConstants2019 {
+    public final static int DRIVE_LEFT_SPARKMAX_A = 10; // CAN 
+    public final static int DRIVE_LEFT_SPARKMAX_B = 11; // CAN 
+    public final static int DRIVE_RIGHT_SPARKMAX_A = 8; // CAN 
+    public final static int DRIVE_RIGHT_SPARKMAX_B = 9; // CAN  
+}

--- a/src/main/java/frc/robot/RobotConstants2020.java
+++ b/src/main/java/frc/robot/RobotConstants2020.java
@@ -1,0 +1,8 @@
+package frc.robot;
+
+public class RobotConstants2020 {
+    public final static int DRIVE_LEFT_SPARKMAX_A = 1; // CAN
+    public final static int DRIVE_LEFT_SPARKMAX_B = 2; // CAN
+    public final static int DRIVE_RIGHT_SPARKMAX_A = 3; // CAN
+    public final static int DRIVE_RIGHT_SPARKMAX_B = 4; // CAN
+}

--- a/src/main/java/frc/robot/RobotConstantsRaft.java
+++ b/src/main/java/frc/robot/RobotConstantsRaft.java
@@ -1,0 +1,13 @@
+package frc.robot;
+
+public class RobotConstantsRaft {
+    public final static int DRIVE_LEFT_VICTOR_A = 0; // PWM 
+    public final static int DRIVE_LEFT_VICTOR_B = 1; // PWM 
+    public final static int DRIVE_LEFT_VICTOR_C = 2; // PWM 
+    public final static int DRIVE_LEFT_TALONSRX = 4; // CAN  
+
+    public final static int DRIVE_RIGHT_VICTOR_A = 3; // PWM
+    public final static int DRIVE_RIGHT_VICTOR_B = 4; // PWM
+    public final static int DRIVE_RIGHT_VICTOR_C = 5; // PWM
+    public final static int DRIVE_RIGHT_TALONSRX = 3; // CAN
+}

--- a/src/main/java/frc/robot/subsystems/DriveBase.java
+++ b/src/main/java/frc/robot/subsystems/DriveBase.java
@@ -20,6 +20,9 @@ import edu.wpi.first.wpilibj.SpeedControllerGroup;
 import edu.wpi.first.wpilibj.Victor;
 import frc.robot.commands.*;
 import frc.robot.Robot;
+import frc.robot.RobotConstants2019;
+import frc.robot.RobotConstants2020;
+import frc.robot.RobotConstantsRaft;
 
 /**
  *
@@ -48,98 +51,101 @@ public class DriveBase extends Subsystem {
         PIDRight = new PIDController(0.4, 0, 0);
         PIDLeft = new PIDController(0.4, 0, 0);
         if (type == Robot.RobotType.raft) {
-            left1 = new Victor(0);
-            addChild("Left1", left1);
-            left1.setInverted(false);
-
-            left2 = new Victor(1);
-            addChild("Left2", left2);
-            left2.setInverted(false);
-
-            left3 = new Victor(2);
-            addChild("Left3", left3);
-            left3.setInverted(false);
-
-            left4 = new WPI_TalonSRX(4);
-            addChild("Left4", left4);
-            left4.setInverted(false);
-
-            leftDrive = new SpeedControllerGroup(left1, left2, left3, left4);
-            addChild("LeftDrive", leftDrive);
-
-            right1 = new Victor(3);
-            addChild("Right1", right1);
-            right1.setInverted(false);
-
-            right2 = new Victor(4);
-            addChild("Right2", right2);
-            right2.setInverted(false);
-
-            right3 = new Victor(5);
-            addChild("Right3", right3);
-            right3.setInverted(false);
-
-            right4 = new WPI_TalonSRX(3);
-            addChild("Right4", right4);
-            right4.setInverted(false);
-
-            rightDrive = new SpeedControllerGroup(right1, right2, right3, right4);
-            addChild("RightDrive", rightDrive);
+            setupRaft();
         }
-
         if (type == Robot.RobotType.chaos2019) {
-            leftSpark1 = new CANSparkMax(10, CANSparkMax.MotorType.kBrushless);
-            // addChild("Left1", leftSpark1);
-            leftSpark1.setInverted(false);
-
-            leftSpark2 = new CANSparkMax(11, CANSparkMax.MotorType.kBrushless);
-            // addChild("Left2", leftSpark2);
-            leftSpark2.setInverted(false);
-
-            leftDrive = new SpeedControllerGroup(leftSpark1, leftSpark2);
-            addChild("LeftDrive", leftDrive);
-
-            rightSpark1 = new CANSparkMax(8, CANSparkMax.MotorType.kBrushless);
-            // addChild("Right1", rightSpark1);
-            rightSpark1.setInverted(false);
-
-            rightSpark2 = new CANSparkMax(9, CANSparkMax.MotorType.kBrushless);
-            // addChild("Right2", rightSpark2);
-            rightSpark2.setInverted(false);
-
-            rightDrive = new SpeedControllerGroup(rightSpark1, rightSpark2);
-            addChild("RightDrive", rightDrive);
+            setup2019();
+        }
+        if (type == Robot.RobotType.chaos2020) {
+            setup2020();
         }
 
-        if(type == Robot.RobotType.chaos2020){
-            leftSpark1 = new CANSparkMax(1, CANSparkMax.MotorType.kBrushless);
-            //addChild("Left1", leftSpark1);
-            leftSpark1.setInverted(false);
-
-            leftSpark2 = new CANSparkMax(2, CANSparkMax.MotorType.kBrushless);
-            //addChild("Left2", leftSpark2);
-            leftSpark2.setInverted(false);
-
-            leftDrive = new SpeedControllerGroup(leftSpark1, leftSpark2);
-            addChild("LeftDrive", leftDrive);
-
-            rightSpark1 = new CANSparkMax(3, CANSparkMax.MotorType.kBrushless);
-            //addChild("Right1", rightSpark1);
-            rightSpark1.setInverted(false);
-
-            rightSpark2 = new CANSparkMax(4, CANSparkMax.MotorType.kBrushless);
-            //addChild("Right2", rightSpark2);
-            rightSpark2.setInverted(false);
-
-            rightDrive = new SpeedControllerGroup(rightSpark1, rightSpark2);
-            addChild("RightDrive", rightDrive);
-        }
-
+        addChild("LeftDrive", leftDrive);
+        addChild("RightDrive", rightDrive);
         differentialDrive1 = new DifferentialDrive(leftDrive, rightDrive);
         addChild("Differential Drive 1", differentialDrive1);
         differentialDrive1.setSafetyEnabled(true);
         differentialDrive1.setExpiration(0.1);
         differentialDrive1.setMaxOutput(1.0);
+    }
+
+    private void setupRaft() {
+        left1 = new Victor(RobotConstantsRaft.DRIVE_LEFT_VICTOR_A);
+        addChild("Left1", left1);
+        left1.setInverted(false);
+
+        left2 = new Victor(RobotConstantsRaft.DRIVE_LEFT_VICTOR_B);
+        addChild("Left2", left2);
+        left2.setInverted(false);
+
+        left3 = new Victor(RobotConstantsRaft.DRIVE_LEFT_VICTOR_C);
+        addChild("Left3", left3);
+        left3.setInverted(false);
+
+        left4 = new WPI_TalonSRX(RobotConstantsRaft.DRIVE_LEFT_TALONSRX);
+        addChild("Left4", left4);
+        left4.setInverted(false);
+
+        right1 = new Victor(RobotConstantsRaft.DRIVE_RIGHT_VICTOR_A);
+        addChild("Right1", right1);
+        right1.setInverted(false);
+
+        right2 = new Victor(RobotConstantsRaft.DRIVE_RIGHT_VICTOR_B);
+        addChild("Right2", right2);
+        right2.setInverted(false);
+
+        right3 = new Victor(RobotConstantsRaft.DRIVE_RIGHT_VICTOR_C);
+        addChild("Right3", right3);
+        right3.setInverted(false);
+
+        right4 = new WPI_TalonSRX(RobotConstantsRaft.DRIVE_RIGHT_TALONSRX);
+        addChild("Right4", right4);
+        right4.setInverted(false);
+
+        leftDrive = new SpeedControllerGroup(left1, left2, left3, left4);
+        rightDrive = new SpeedControllerGroup(right1, right2, right3, right4);
+    }
+
+    private void setup2019() {
+        leftSpark1 = new CANSparkMax(RobotConstants2019.DRIVE_LEFT_SPARKMAX_A, CANSparkMax.MotorType.kBrushless);
+        // addChild("Left1", leftSpark1);
+        leftSpark1.setInverted(false);
+
+        leftSpark2 = new CANSparkMax(RobotConstants2019.DRIVE_LEFT_SPARKMAX_B, CANSparkMax.MotorType.kBrushless);
+        // addChild("Left2", leftSpark2);
+        leftSpark2.setInverted(false);
+
+        rightSpark1 = new CANSparkMax(RobotConstants2019.DRIVE_RIGHT_SPARKMAX_A, CANSparkMax.MotorType.kBrushless);
+        // addChild("Right1", rightSpark1);
+        rightSpark1.setInverted(false);
+
+        rightSpark2 = new CANSparkMax(RobotConstants2019.DRIVE_RIGHT_SPARKMAX_B, CANSparkMax.MotorType.kBrushless);
+        // addChild("Right2", rightSpark2);
+        rightSpark2.setInverted(false);
+
+        leftDrive = new SpeedControllerGroup(leftSpark1, leftSpark2);
+        rightDrive = new SpeedControllerGroup(rightSpark1, rightSpark2);
+    }
+
+    private void setup2020() {
+        leftSpark1 = new CANSparkMax(RobotConstants2020.DRIVE_LEFT_SPARKMAX_A, CANSparkMax.MotorType.kBrushless);
+        // addChild("Left1", leftSpark1);
+        leftSpark1.setInverted(false);
+
+        leftSpark2 = new CANSparkMax(RobotConstants2020.DRIVE_LEFT_SPARKMAX_B, CANSparkMax.MotorType.kBrushless);
+        // addChild("Left2", leftSpark2);
+        leftSpark2.setInverted(false);
+
+        rightSpark1 = new CANSparkMax(RobotConstants2020.DRIVE_RIGHT_SPARKMAX_A, CANSparkMax.MotorType.kBrushless);
+        // addChild("Right1", rightSpark1);
+        rightSpark1.setInverted(false);
+
+        rightSpark2 = new CANSparkMax(RobotConstants2020.DRIVE_RIGHT_SPARKMAX_B, CANSparkMax.MotorType.kBrushless);
+        // addChild("Right2", rightSpark2);
+        rightSpark2.setInverted(false);
+
+        leftDrive = new SpeedControllerGroup(leftSpark1, leftSpark2);
+		rightDrive = new SpeedControllerGroup(rightSpark1, rightSpark2);
     }
 
     private double encoderInches(WPI_TalonSRX driveInput) {


### PR DESCRIPTION
The code supports running on 3 different robots (raft, 2019 and 2020), so move the wiring constants for each robot into a separate file.  This change also splits the DriveBase constructor into separate methods for setting up each robot.

On Wednesday we can work on making DriveBase.getLeftPosition and DriveBase.getRightPosition work with multiple encoder types and wheel sizes.