### PR TITLE
Adds classes for convenient sending and receiving Dashboard updates (including PID values)

### DIFF
--- a/src/main/java/frc/robot/util/dashboard/BaseDashboardValue.java
+++ b/src/main/java/frc/robot/util/dashboard/BaseDashboardValue.java
@@ -1,0 +1,77 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.util.dashboard;
+
+import java.util.function.Consumer;
+
+import edu.wpi.first.networktables.EntryListenerFlags;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableValue;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import frc.robot.util.LogUtils;
+
+/**
+ * An editable value that will automatically send/retrive from the Dashboard
+ */
+public abstract class BaseDashboardValue<T> {
+    protected final String key;
+    protected T value;
+    private NetworkTableEntry dashboardEntry;
+
+    /**
+     * Creates a BaseDashboardValue that can be used to track values fom the dashboard
+     * @param key - the name of the value to save to the dashboard
+     * @param startingValue - the intitial value
+     * @param onChangeFunction - a function that will be triggered whenever the value is changed on the dashboard
+     */
+    public BaseDashboardValue(String key, T startingValue, Consumer<T> onChangeFunction) {
+        // Save the key and initial value
+        this.key = key;
+        set(startingValue);
+
+        dashboardEntry = SmartDashboard.getEntry(key);
+
+        // Set up an event listener for dashboard changes
+        dashboardEntry.addListener(event -> {
+            // For every new/updated event received, cache the converted value and call the onChangeFunction if supplied
+            value = convertNetworkTableEntryToTargetType(event.value);
+            LogUtils.log(String.format("BaseDashboardValue %s updated: %s", key, value.toString()));
+            if(onChangeFunction != null) {
+                onChangeFunction.accept(value);
+            }
+        }, EntryListenerFlags.kNew | EntryListenerFlags.kUpdate);
+    }
+
+    /**
+     * Gets the current cached value
+     */
+    public T get(){
+        return this.value;
+    }
+
+    /**
+     * Sets the current value on the dashboard and caches it locally
+     * @param value - the value to set
+     */
+    public void set(T value){
+        this.value = value;
+        putToDashboard(value);
+    }
+
+    /**
+     * Converts the entry into the current target type
+     * @param entry - the entry to convert
+     */
+    protected abstract T convertNetworkTableEntryToTargetType(NetworkTableValue entry);
+
+    /**
+     * Sets the current value on the dashboard (must be declared in subclasses)
+     * @param value - the value to set
+     */
+    protected abstract void putToDashboard(T value);
+}

--- a/src/main/java/frc/robot/util/dashboard/NumberDashboardValue.java
+++ b/src/main/java/frc/robot/util/dashboard/NumberDashboardValue.java
@@ -1,0 +1,48 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.util.dashboard;
+
+import java.util.function.Consumer;
+
+import edu.wpi.first.networktables.NetworkTableValue;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+
+/**
+ * An editable number that will automatically send/retrive from the Dashboard
+ */
+public class NumberDashboardValue extends BaseDashboardValue<Double> {
+
+    /**
+     * Creates a NumberDashboardValue that can be used to track values fom the dashboard
+     * @param key - the name of the value to save to the dashboard
+     * @param startingValue - the intitial value
+     */
+    public NumberDashboardValue(String key, Double startingValue) {
+        super(key, startingValue, null);
+    }
+
+    /**
+     * Creates a NumberDashboardValue that can be used to track values fom the dashboard
+     * @param key - the name of the value to save to the dashboard
+     * @param startingValue - the intitial value
+     * @param onChangeFunction - a function that will be triggered whenever the value is changed on the dashboard
+     */
+    public NumberDashboardValue(String key, Double startingValue, Consumer<Double> onChangeFunction) {
+        super(key, startingValue, onChangeFunction);
+    }
+
+    @Override
+    protected void putToDashboard(Double value) {
+        SmartDashboard.putNumber(key, value);
+    }
+
+    @Override
+    protected Double convertNetworkTableEntryToTargetType(NetworkTableValue entry) {
+        return entry.getDouble();
+    }
+}

--- a/src/main/java/frc/robot/util/dashboard/PIDDashboardUpdater.java
+++ b/src/main/java/frc/robot/util/dashboard/PIDDashboardUpdater.java
@@ -1,0 +1,110 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2018-2019 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+package frc.robot.util.dashboard;
+
+import java.util.function.Consumer;
+
+import com.revrobotics.CANPIDController;
+
+import edu.wpi.first.wpilibj.controller.PIDController;
+import frc.robot.util.LogUtils;
+
+/**
+ * An updater class that will keep the P, I, and D of the dashboard synced down to the given PIDController
+ */
+public class PIDDashboardUpdater {
+    private final NumberDashboardValue p, i, d;
+    private final String entityKey;
+    
+    /**
+     * Created a PIDDashboardUpdater with the specified arguments
+     * @param entityKey - the name of the entity to create dashboard values for
+     * @param startingP - the initial p
+     * @param startingI - the initial i
+     * @param startingD - the initial d
+     * @param pChanged - the function to run when p is changed
+     * @param iChanged - the function to run when i is changed
+     * @param dChanged - the function to run when d is changed
+     */
+    private PIDDashboardUpdater(String entityKey, double startingP, double startingI, double startingD, Consumer<Double> pChanged, Consumer<Double> iChanged, Consumer<Double> dChanged) {
+        this.entityKey = entityKey;
+        p = new NumberDashboardValue(entityKey + "/pid/p", startingP, pChanged);
+        i = new NumberDashboardValue(entityKey + "/pid/i", startingI, iChanged);
+        d = new NumberDashboardValue(entityKey + "/pid/d", startingD, dChanged);
+    }
+
+    /**
+     * Gets the current P from the dashboard
+     */
+    public double getP() {
+        return p.get();
+    }
+
+    /**
+     * Gets the current I from the dashboard
+     */
+    public double getI() {
+        return i.get();
+    }
+
+    /**
+     * Gets the current D from the dashboard
+     */
+    public double getD() {
+        return d.get();
+    }
+
+    /**
+     * Logs a message that displays the current P, I, and D values
+     */
+    public void logPID() {
+        LogUtils.log(String.format("Default PID values for %s. p=%f, i=%f, d=%f", entityKey, getP(), getI(), getD()));
+    }
+
+    /**
+     * Create a PIDDashboardUpdater for the PIDController from WPILib
+     * @param pidControler - the pidController to update values for
+     * @param entityKey - the name of the entity to create dashboard values for
+     * @param startingP - the initial p
+     * @param startingI - the initial i
+     * @param startingD - the initial d
+     */
+    public static PIDDashboardUpdater createDashboardPID(PIDController pidControler, String entityKey, double startingP, double startingI, double startingD) {
+        Consumer<Double> pChanged = (Double newValue) -> {
+            pidControler.setP(newValue);
+        };
+        Consumer<Double> iChanged = (Double newValue) -> {
+            pidControler.setI(newValue);
+        };
+        Consumer<Double> dChanged = (Double newValue) -> {
+            pidControler.setD(newValue);
+        };
+        return new PIDDashboardUpdater(entityKey, startingP, startingI, startingD, pChanged, iChanged, dChanged);
+    }
+
+    /**
+     * Create a PIDDashboardUpdater for the PIDController from a REV Robotics
+     * @param pidControler - the pidController to update values for
+     * @param entityKey - the name of the entity to create dashboard values for
+     * @param startingP - the initial p
+     * @param startingI - the initial i
+     * @param startingD - the initial d
+     */
+    public static PIDDashboardUpdater createDashboardPID(CANPIDController pidControler, String entityKey, double startingP, double startingI, double startingD) {
+        Consumer<Double> pChanged = (Double newValue) -> {
+            pidControler.setP(newValue);
+        };
+        Consumer<Double> iChanged = (Double newValue) -> {
+            pidControler.setI(newValue);
+        };
+        Consumer<Double> dChanged = (Double newValue) -> {
+            pidControler.setD(newValue);
+        };
+        return new PIDDashboardUpdater(entityKey, startingP, startingI, startingD, pChanged, iChanged, dChanged);
+    }
+}


### PR DESCRIPTION
This creates wrappers for Dashboard values so that the getting/setting of those values are consistent (and don't require remembering the constant string name you gave them).

It doesn't make a getNumber call every loop either - it will actually listen for events and update a cached value instead (not sure if this actually improves any performance)

I also created a PID wrapper class that will handle adding P, I, and D for a system to the dashboard and will automatically update the given PIDController when they change.

@calebur 
I'm not sure if we actually want to merge this in. I mostly wanted to try it out and was bored tonight. 
If we do want it, we should either make sure the kids really understand it or make them write their own version.
I only created a `Number` class. We could make them add a `String` and `Boolean` class (though not really sure they are needed anyways)