### PR TITLE
Pan fixes for slowing down at limits and avoiding oscillation while aiming

### DIFF
--- a/src/main/java/frc/robot/RobotConstants2020.java
+++ b/src/main/java/frc/robot/RobotConstants2020.java
@@ -30,6 +30,8 @@ public class RobotConstants2020 {
     public final static int MAX_PAN_RAW = 502; // 2021-03-13
     public final static int PAN_ZERO_RAW = 338; // TODO: change
     public final static int PAN_BACKWARD_RAW = 30; // TODO: change!!!!!!!!!!!!!!!!
+    public final static int PAN_SLOWDOWN_THRESHOLD = 50; // TODO: change!!!!!!!!!!!!!!!!
+    public final static double PAN_MIN_POWER = 0.1; // TODO: change!!!!!!!!!!!!!!!!
 
     public final static int MIN_HOOD_RAW = 68; // 2021-03-13 - 64 hard stop
     public final static int MAX_HOOD_RAW = 164; // 2021-03-13 - 168 hard stop

--- a/src/main/java/frc/robot/RobotConstants2020.java
+++ b/src/main/java/frc/robot/RobotConstants2020.java
@@ -30,8 +30,8 @@ public class RobotConstants2020 {
     public final static int MAX_PAN_RAW = 502; // 2021-03-13
     public final static int PAN_ZERO_RAW = 338; // TODO: change
     public final static int PAN_BACKWARD_RAW = 30; // TODO: change!!!!!!!!!!!!!!!!
-    public final static int PAN_SLOWDOWN_THRESHOLD = 50; // TODO: change!!!!!!!!!!!!!!!!
-    public final static double PAN_MIN_POWER = 0.1; // TODO: change!!!!!!!!!!!!!!!!
+    public final static int PAN_SLOWDOWN_THRESHOLD = 45; // TODO: change!!!!!!!!!!!!!!!!
+    public final static double PAN_MIN_POWER = 0.25; // TODO: change!!!!!!!!!!!!!!!!
 
     public final static int MIN_HOOD_RAW = 68; // 2021-03-13 - 64 hard stop
     public final static int MAX_HOOD_RAW = 164; // 2021-03-13 - 168 hard stop

--- a/src/main/java/frc/robot/commands/turret/AimTurret.java
+++ b/src/main/java/frc/robot/commands/turret/AimTurret.java
@@ -46,16 +46,14 @@ public class AimTurret extends DoneCommand {
 
       Robot.flywheel.setTarget(targetData.getSpeed());
     
-    Robot.turret.PIDDrive(true);
+      //Robot.turret.PIDDrive(true);
 
     } else {
-      //Robot.turret.setTiltTargetAngle(RobotConstants2020.MIDDLE_HOOD_RAW);
-      Robot.turret.setPanTarget(0);
-    Robot.turret.PIDDrive(false);
-
-
+      // Robot.turret.setTiltTargetAngle(RobotConstants2020.MIDDLE_HOOD_RAW);
+      // Robot.turret.setPanTarget(0);
+      // Robot.turret.PIDDrive(false);
     }
-    //Robot.turret.PIDDrive(true);
+    Robot.turret.PIDDrive(true);
   }
 
   // Make this return true when this Command no longer needs to run execute()

--- a/src/main/java/frc/robot/commands/turret/BumperShotAim.java
+++ b/src/main/java/frc/robot/commands/turret/BumperShotAim.java
@@ -16,13 +16,13 @@ public class BumperShotAim extends CommandBase {
   }
 
   private final double FLYWHEEL_SPEED = 4500;
-  private final double TURRET_TILT = 65;
+  private final double TURRET_TILT = 74;
 
   // Called just before this Command runs the first time
   @Override
   public void initialize() {
     Robot.turret.setTiltTargetAngle(TURRET_TILT);
-    Robot.turret.setPanTarget(0);
+    Robot.turret.setPanTarget(-180);
     Robot.flywheel.setTarget(FLYWHEEL_SPEED);
   }
 

--- a/src/main/java/frc/robot/commands/turret/SetThroatSpeed.java
+++ b/src/main/java/frc/robot/commands/turret/SetThroatSpeed.java
@@ -24,10 +24,10 @@ public class SetThroatSpeed extends DoneCommand {
 
     this.on = on;
     // Use addRequirements() here to declare subsystem dependencies.
-    SmartDashboard.putNumber("Throat Min", 300);
+    //SmartDashboard.putNumber("Throat Min", 300);
   }
 
-  double minThroat;
+  double minThroat = 600;
 
   // Called when the command is initially scheduled.
   @Override
@@ -39,8 +39,7 @@ public class SetThroatSpeed extends DoneCommand {
   public void execute() {
 
     Robot.throat.ejectorSpeed(on);
-    SmartDashboard.putNumber("Throat RPM", Robot.throat.getThroatSpeed());
-    minThroat = SmartDashboard.getNumber("Throat Min", 300);
+   
   }
 
   // Called once the command ends or is interrupted.
@@ -57,7 +56,7 @@ public class SetThroatSpeed extends DoneCommand {
   @Override
   public boolean isDone() {
     double currentSpeed = Robot.throat.getThroatSpeed();
-    LogUtils.log("SetThroatSpeed is done");
+   // LogUtils.log("SetThroatSpeed is done");
     return currentSpeed > minThroat;
   }
 }

--- a/src/main/java/frc/robot/commands/turret/TurretDefault.java
+++ b/src/main/java/frc/robot/commands/turret/TurretDefault.java
@@ -24,7 +24,7 @@ public class TurretDefault extends CommandBase {
   @Override
   public void initialize() {
     //Robot.turret.setTiltTargetAngle(RobotConstants2020.MIN_HOOD_RAW + 5);
-    panSpeedScale = 0.30;
+    panSpeedScale = 0.60;
   }
 
   // Called repeatedly when this Command is scheduled to run

--- a/src/main/java/frc/robot/subsystems/turret/Turret.java
+++ b/src/main/java/frc/robot/subsystems/turret/Turret.java
@@ -128,8 +128,11 @@ public class Turret extends SubsystemBase implements ITurret {
   public void setPanSpeed(double speed) {
     double currentPanPosition = speedControllerPan.getSensorCollection().getAnalogInRaw();
     double slowdownThreshold = RobotConstants2020.PAN_SLOWDOWN_THRESHOLD;
-    double distanceToMin = currentPanPosition - minRawPan;
-    double distanceToMax = maxRawPan - currentPanPosition;
+    double currentAngle = getPanAngle(); 
+    double minAngle = turretPanRawToDegrees(minRawPan);
+    double maxAngle = turretPanRawToDegrees(maxRawPan);
+    double distanceToMin = Math.abs(currentAngle - minAngle);
+    double distanceToMax = Math.abs(currentAngle - maxAngle);
 
     if (currentPanPosition <= minRawPan && speed < 0) {
       speed = 0;
@@ -181,7 +184,7 @@ public class Turret extends SubsystemBase implements ITurret {
   }
 
   public double getTiltAngle() {
-    return speedControllerTilt.getSensorCollection().getAnalogIn() - 1023; // subtracting an offset to get angle values back to their original state after replacing sensor
+    return speedControllerTilt.getSensorCollection().getAnalogIn(); // subtracting an offset to get angle values back to their original state after replacing sensor
   }
 
   public double getHoodSpeed() {

--- a/src/main/java/frc/robot/subsystems/turret/Turret.java
+++ b/src/main/java/frc/robot/subsystems/turret/Turret.java
@@ -21,6 +21,19 @@ import com.ctre.phoenix.motorcontrol.can.WPI_TalonSRX;
 public class Turret extends SubsystemBase implements ITurret {
   final boolean tuning = false;
 
+  private double panP, panI, panD, tiltP, tiltI, tiltD, camPanP, camPanI, camPanD;
+
+  private int minRawTilt, maxRawTilt, minRawPan, maxRawPan;
+
+
+  // private double minAnglePan, maxAnglePan;
+  // private double slopePan, interceptPan;
+  PIDController pidPan, pidTilt, camPanPID;
+  WPI_TalonSRX speedControllerPan, speedControllerTilt;
+  private double panError, tiltError;
+
+  double panMultiplier = 0.05;
+
   // Put methods for controlling this subsystem
   // here. Call these from Commands.
   public Turret() {
@@ -94,16 +107,6 @@ public class Turret extends SubsystemBase implements ITurret {
 
   }
 
-  private double panP, panI, panD, tiltP, tiltI, tiltD, camPanP, camPanI, camPanD;
-  private int minRawTilt, maxRawTilt, minRawPan, maxRawPan;
-  // private double minAnglePan, maxAnglePan;
-  // private double slopePan, interceptPan;
-  PIDController pidPan, pidTilt, camPanPID;
-  WPI_TalonSRX speedControllerPan, speedControllerTilt;
-  private double panError, tiltError;
-
-  double panMultiplier = 0.05;
-
   private double turretPanRawToDegrees(double raw) {
     // return ((-0.0062 * raw * raw) + (4.418 * raw) - 684.81);
     // return ((-0.0079 * raw * raw) + (5.36 * raw) - 795);
@@ -123,12 +126,26 @@ public class Turret extends SubsystemBase implements ITurret {
   }
 
   public void setPanSpeed(double speed) {
-    if (speedControllerPan.getSensorCollection().getAnalogInRaw() <= minRawPan && speed < 0) {
+    double currentPanPosition = speedControllerPan.getSensorCollection().getAnalogInRaw();
+    double slowdownThreshold = RobotConstants2020.PAN_SLOWDOWN_THRESHOLD;
+    double distanceToMin = currentPanPosition - minRawPan;
+    double distanceToMax = maxRawPan - currentPanPosition;
+
+    if (currentPanPosition <= minRawPan && speed < 0) {
       speed = 0;
     }
-    if (speedControllerPan.getSensorCollection().getAnalogInRaw() >= maxRawPan && speed > 0) {
+    else if (distanceToMin <= slowdownThreshold && speed < 0) {
+      var percentToLimit = distanceToMin / slowdownThreshold;
+      speed = Math.min(RobotConstants2020.PAN_MIN_POWER * -1.0, speed * percentToLimit);
+    }
+    else if (currentPanPosition >= maxRawPan && speed > 0) {
       speed = 0;
     }
+    else if (distanceToMax <= slowdownThreshold && speed > 0) {
+      var percentToLimit = distanceToMax / slowdownThreshold;
+      speed = Math.max(RobotConstants2020.PAN_MIN_POWER, speed * percentToLimit);
+    }
+
     speedControllerPan.set(speed);
   }
 


### PR DESCRIPTION
This does 2 things:

1. Slows down panning as you approach the limits 
    - It will slow down linearly as it approaches a limit, with a constant for a threshold and a min power
2. When Aiming the Turret, if the target is lost, the turret will pan to the last known target still. Before it would reset. 
    - I assume this is what was causing the oscillation. 